### PR TITLE
Fix: Email bugs

### DIFF
--- a/scenes/Computer Scenes/computer_interface.tscn
+++ b/scenes/Computer Scenes/computer_interface.tscn
@@ -201,7 +201,7 @@ layout_mode = 2
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_gobfx")
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Sites/Emails"]
+[node name="EmailScrollContainer" type="ScrollContainer" parent="Sites/Emails"]
 layout_mode = 0
 offset_left = 431.0
 offset_top = 185.0
@@ -213,13 +213,13 @@ horizontal_scroll_mode = 0
 script = ExtResource("5_wwlms")
 order_class = ExtResource("6_luoch")
 
-[node name="EmailsListContainer" type="VBoxContainer" parent="Sites/Emails/ScrollContainer"]
+[node name="EmailsListContainer" type="VBoxContainer" parent="Sites/Emails/EmailScrollContainer"]
 clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="EmailButton" parent="Sites/Emails/ScrollContainer/EmailsListContainer" instance=ExtResource("1_ip337")]
+[node name="EmailButton" parent="Sites/Emails/EmailScrollContainer/EmailsListContainer" instance=ExtResource("1_ip337")]
 layout_mode = 2
 
 [node name="Label" type="Label" parent="Sites/Emails"]

--- a/scripts/resources/email.gd
+++ b/scripts/resources/email.gd
@@ -25,7 +25,7 @@ var category: String = "main"
 @export var failed: bool
 @export var prereqs_must_fail: bool # This is for conditions where an email only appears after something /fails/, something Everett requested
 @export var bankruptcy: bool = false
-
+var displayed: bool = false
 ## Whether or not the email was archived, only used visually so we don't have to navigate the list every frame
 var archived: bool = false
 


### PR DESCRIPTION
- Displays emails after tutorial (2 per day out of valid emails)
- displays emails in order received
- updates email list immediately (**** the scroll is a bit funky here, when a new email is added it still resets and scrolls to the top, a fix is in progress)
- fixed accept/reject order bug (previously allowed user to accept an order multiple times by clicking it a lot, adding extra stuff to their inventory)