### PR TITLE
fix/clock aligned with audio + time pass bugfix

### DIFF
--- a/scenes/clock.gd
+++ b/scenes/clock.gd
@@ -27,7 +27,7 @@ func _process(_delta: float) -> void:
 		day_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
 		time_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
 	
-	if game_time["hour"] > GameManager.continue_clock_in_computer:
+	if GameManager.time_final:
 		if modulate.a >0.5:
 			modulate.a -= 0.005
 		elif modulate.a <= 0.5 and current_minute != game_time["minute"]:

--- a/scripts/gamemanager.gd
+++ b/scripts/gamemanager.gd
@@ -74,7 +74,8 @@ var day_hours: int  = 18
 var time_scale: int = 480 # 1 irl second is 480 game seconds for 2 minutes/day, 16h day
 var time_scaled_seconds: int
 var time_difference
-var continue_clock_in_computer = 22
+var continue_clock_in_computer: int = 5000
+var time_final: bool
 var sleeping: bool
 var sleeping_time
 var sleep_start
@@ -189,21 +190,21 @@ func _process(_delta: float) -> void:
 					
 func _physics_process(_delta: float) -> void:
 	# time tracking
-	if !pause and !in_computer or (!pause and in_computer and game_time["hour"] >= continue_clock_in_computer) or (in_computer and game_time["hour"] == start_time and game_time["minute"] == 0):
+	milliseconds_elapsed = active_time
+	seconds_elapsed = milliseconds_elapsed / 1000
+	time_scaled_seconds = seconds_elapsed*time_scale
+	var less_rounded_seconds:int = int(milliseconds_elapsed / 1000.0 * time_scale)
+	time_final = less_rounded_seconds >= max_time_seconds - continue_clock_in_computer # If it is time to start ticking and playing the audio
+	if !pause and !in_computer or (!pause and in_computer and time_final) or (in_computer and game_time["hour"] == start_time and game_time["minute"] == 0):
 		current_time = Time.get_ticks_msec()
 		time_difference = current_time - start_time
 		start_time = Time.get_ticks_msec()
 		if !sleeping:
 			active_time += time_difference
-
-		milliseconds_elapsed = active_time
-		seconds_elapsed = milliseconds_elapsed / 1000
-		time_scaled_seconds = seconds_elapsed*time_scale
-		var less_rounded_seconds:int = int(milliseconds_elapsed / 1000.0 * time_scale)
 	
 		if !sleeping:
 			update_time(time_scaled_seconds)
-			if (less_rounded_seconds >= max_time_seconds - 5000):
+			if (time_final):
 				if not day_end_sound.playing:
 					day_end_sound.play()
 		elif sleeping: # TODO: whatever animations, etc

--- a/scripts/objects/gadget.gd
+++ b/scripts/objects/gadget.gd
@@ -127,7 +127,7 @@ func _physics_process(delta: float) -> void:
 		else:
 			if AudioManager.active_gadgets[gadget_stats.sound_string].has(self):
 				AudioManager.active_gadgets[gadget_stats.sound_string].erase(self)
-	if !disabled and !progressing or (!progressing and selected_recipe != null):
+	if !disabled and !progressing or (!progressing and selected_recipe != null) and not GameManager.sleeping:
 		if gadget_stats.name == "Conveyor Belt":
 			do_transport()
 		elif selected_recipe != null:


### PR DESCRIPTION
Aligns the clock flashing (and the computer accessing) with the audio, and fixes a bug where time passing would sometimes nuke all of the coal in a generator.