### PR TITLE
fix/prevents resource tree from rendering/updating if not open

### DIFF
--- a/addons/resource_tree/email_node.gd
+++ b/addons/resource_tree/email_node.gd
@@ -68,6 +68,7 @@ func _ready():
 	default_bottom_bar = bottom_bar.texture
 
 func _process(_delta: float) -> void:
+	if !get_parent_control().visible: return
 	if email_node == null or email_node.email == null:
 		return
 	if !email_node.order_currency_changed.is_connected(_order_currency_changed): 

--- a/addons/resource_tree/gadget_node.gd
+++ b/addons/resource_tree/gadget_node.gd
@@ -14,6 +14,7 @@ func _ready() -> void:
 	close_node.pressed.connect(close_pressed)
 
 func _process(_delta: float) -> void:
+	if !get_parent_control().visible: return
 	if gadget_node == null: return
 	if gadget_node.gadget == null:
 		$GadgetImage.texture = null

--- a/addons/resource_tree/item_node.gd
+++ b/addons/resource_tree/item_node.gd
@@ -14,6 +14,7 @@ func _ready() -> void:
 	close_node.pressed.connect(close_pressed)
 
 func _process(_delta: float) -> void:
+	if !get_parent_control().visible: return
 	if item_node == null: return
 	if item_node.item == null: return
 	if $ItemImage.texture != item_node.item.texture:

--- a/addons/resource_tree/recipe_node.gd
+++ b/addons/resource_tree/recipe_node.gd
@@ -13,6 +13,7 @@ func _ready() -> void:
 	spinbox = load("res://addons/resource_tree/spin_box.tscn")
 
 func _process(_delta: float) -> void:
+	if !get_parent_control().visible: return
 	if recipe_node != null:
 		if recipe_node.recipe == null:
 			return

--- a/addons/resource_tree/resource_tree.gd
+++ b/addons/resource_tree/resource_tree.gd
@@ -72,7 +72,7 @@ func _ready() -> void:
 	gadget_menu.index_pressed.connect(gadget_menu_pressed)
 	load_recipes()
 	EditorInterface.get_resource_filesystem().filesystem_changed.connect(load_recipes)
-
+	
 func _has_main_screen() -> bool:
 	return true
 	
@@ -315,6 +315,7 @@ func _on_disconnect_request(from, from_port, to, to_port) -> void:
 	
 
 func _process(_delta:float) -> void:
+	if (!control.visible): return
 	populate_nodes("recipe_node", properties.recipe_nodes, recipe_node)
 	populate_nodes("gadget_node", properties.gadget_nodes, gadget_node)
 	populate_nodes("item_node", properties.item_nodes, item_node)


### PR DESCRIPTION
The resource tree doesn't render if it isn't open, reducing glitches and lag.