### PR TITLE
fix/prices are aligned to the right now

### DIFF
--- a/scenes/Computer Scenes/computer_interface.tscn
+++ b/scenes/Computer Scenes/computer_interface.tscn
@@ -482,15 +482,19 @@ offset_top = 7.0
 offset_bottom = 987.0
 
 [node name="Currency Label" type="Label" parent="."]
-layout_mode = 0
-offset_left = 1475.0
-offset_top = 13.5
-offset_right = 1811.0
-offset_bottom = 91.5
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 1.003
+anchor_right = 1.003
+offset_left = -448.745
+offset_top = 13.0
+offset_right = -112.745
+offset_bottom = 92.0
+grow_horizontal = 0
 theme_override_fonts/font = ExtResource("3_gp3as")
 theme_override_font_sizes/font_size = 50
 theme_override_styles/normal = SubResource("StyleBoxTexture_xtmmj")
-text = "0123456"
+text = "0"
 horizontal_alignment = 2
 vertical_alignment = 1
 


### PR DESCRIPTION
Makes prices aligned to the right to avoid them scaling to overlap with the X button